### PR TITLE
Readme fixes 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-AUTOMAKE_OPTIONS = gnu
+AUTOMAKE_OPTIONS = foreign
 SUBDIRS=src
 include_fpllldir=$(includedir)/fplll
 EXTRA_DIST=README.html tools/reformat.pl tools/reformat_magma.pl tools/plot_gso_dump.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,3 @@
-AUTOMAKE_OPTIONS = foreign
 SUBDIRS=src
 include_fpllldir=$(includedir)/fplll
 EXTRA_DIST=README.md tools/reformat.pl tools/reformat_magma.pl tools/plot_gso_dump.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS=src
 include_fpllldir=$(includedir)/fplll
-EXTRA_DIST=README.html tools/reformat.pl tools/reformat_magma.pl tools/plot_gso_dump.py
+EXTRA_DIST=README.md tools/reformat.pl tools/reformat_magma.pl tools/plot_gso_dump.py
 ACLOCAL_AMFLAGS=-I m4

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ(2.61)
 AC_INIT(libfplll,4.0.5)
 AC_CONFIG_SRCDIR([src/fplll.cpp])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 AC_CONFIG_HEADER(config.h)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,3 @@
-AUTOMAKE_OPTIONS=gnu
-
 include_fpllldir=$(includedir)/fplll
 
 include_fplll_HEADERS=defs.h dpe.h fplll.h matrix.h matrix.cpp nr.h \


### PR DESCRIPTION
Switching to README.md created some minor problems:

- We don't obey the GNU project's recommendations any more by dropping the README file
- tarball creation would fail because it still tried to include README.html