### PR TITLE
Travis won't send e-mail to arbitrary e-mail addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,5 @@ script:
   - make dist
 
 notifications:
-  email:
-     - fplll-devel@googlegroups.com
   on_success: change
   on_failure: always


### PR DESCRIPTION
Travis doesn't let us specify arbitrary e-mail addresses for e-mail notification. Thinking about it, this is a good thing as it prevents us from getting all kinds of notifications for forks. Hence, let's remove that section of the config file.