### PR TITLE
BKZ with GH bound + SVPPruning with user bound

### DIFF
--- a/src/bkz.h
+++ b/src/bkz.h
@@ -27,10 +27,10 @@ public:
 
   BKZParam(int blockSize=0, double delta=LLL_DEF_DELTA, int flags=BKZ_DEFAULT,
            int maxLoops=0, double maxTime=0, int linearPruningLevel=0,
-           double autoAbort_scale=1.0, int autoAbort_maxNoDec=5) :
+           double autoAbort_scale=1.0, int autoAbort_maxNoDec=5, double ghFactor = 1.1) :
   blockSize(blockSize), delta(delta), flags(flags),
   maxLoops(maxLoops), maxTime(maxTime),
-  autoAbort_scale(autoAbort_scale), autoAbort_maxNoDec(autoAbort_maxNoDec),
+  autoAbort_scale(autoAbort_scale), autoAbort_maxNoDec(autoAbort_maxNoDec), ghFactor(ghFactor),
   dumpGSOFilename("gso.log"), preprocessing(NULL) {
     if (linearPruningLevel > 0) {
       enableLinearPruning(linearPruningLevel);
@@ -65,8 +65,14 @@ public:
   */
   
   vector<double> pruning;
-
-  /** If BKZ_DUMP_GSO us set, the norms of the GSO matrix are written to this
+  
+  /** If BKZ_GH_BND is set, the enumeration bound will be set to ghFactor times
+      the Gaussian Heuristic
+  */
+  
+  double ghFactor;
+  
+  /** If BKZ_DUMP_GSO is set, the norms of the GSO matrix are written to this
       file after each complete round.
   */
   
@@ -96,6 +102,8 @@ public:
 template<class FT>
 static double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow);
 
+template<class FT>
+static void computeGaussHeurDist(MatGSO<Integer, FT>& m, FT& maxDist, long maxDistExpo, int kappa, int blockSize, double ghFactor);
 
 /* The matrix must be LLL-reduced */
 template<class FT>

--- a/src/defs.h
+++ b/src/defs.h
@@ -190,7 +190,8 @@ enum SVPMethod {
 
 enum SVPFlags {
   SVP_DEFAULT = 0,
-  SVP_VERBOSE = 1
+  SVP_VERBOSE = 1,
+  SVP_OVERRIDE_BND = 2
 };
 
 enum CVPFlags {
@@ -206,7 +207,8 @@ enum BKZFlags {
   BKZ_MAX_TIME = 8,
   BKZ_BOUNDED_LLL = 0x10,
   BKZ_AUTO_ABORT = 0x20,
-  BKZ_DUMP_GSO = 0x40
+  BKZ_DUMP_GSO = 0x40,
+  BKZ_GH_BND = 0x80
 };
 
 enum HKZFlags {

--- a/src/dpe.h
+++ b/src/dpe.h
@@ -701,12 +701,18 @@ dpe_swap (dpe_t x, dpe_t y)
  DPE_MANT (y) = d;
 }
 
-/* Ugly hack: No correct rounding guaranteed */
+/* Ugly hacks: No correct rounding guaranteed */
 
 DPE_INLINE void
 dpe_ugly_log (dpe_t x, const dpe_t y)
 {
   dpe_set_d (x, ((double) DPE_EXP(y)) *  0.301 + log (DPE_MANT(y))); 
+}
+
+DPE_INLINE void
+dpe_ugly_exp (dpe_t x, const dpe_t y)
+{
+  dpe_set_d (x, exp(((double) DPE_MANT(y)) * pow(2, ((double)DPE_EXP(y))))); 
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,8 @@ int bkz(Options& o, IntMatrix& b) {
   param.flags = o.bkzFlags;
   if (o.bkzFlags & BKZ_DUMP_GSO)
     param.dumpGSOFilename = o.bkzDumpGSOFilename;
+  if (o.bkzFlags & BKZ_GH_BND)
+    param.ghFactor = o.bkzGHFactor;
   if (o.verbose) param.flags |= BKZ_VERBOSE;
   if (o.noLLL) param.flags |= BKZ_NO_LLL;
   if (o.pruningFile != NULL) {
@@ -307,13 +309,19 @@ void readOptions(int argc, char** argv, Options& o) {
     }
     else if (strcmp(argv[ac], "-bkzlinearpruning") == 0) {
       ++ac;
-      CHECK(ac < argc, "missing filename after -bkzdumpgso switch");
+      CHECK(ac < argc, "missing value after -bkzlinearpruning switch");
       o.bkzLinearPruningLevel = atol(argv[ac]);
     }
     else if (strcmp(argv[ac], "-c") == 0) {
       ++ac;
       CHECK(ac < argc, "missing value after -c switch");
       //o.c=atoi(argv[ac]); // ignored (was the number of columns)
+    }
+    else if (strcmp(argv[ac], "-bkzghbound") == 0) {
+      ++ac;
+      CHECK(ac < argc, "missing value after '-bkzghbound'");
+      o.bkzGHFactor = atof(argv[ac]);
+      o.bkzFlags |= BKZ_GH_BND;
     }
     else if (strcmp(argv[ac], "-d") == 0 || strcmp(argv[ac], "-delta") == 0) {
       ++ac;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,8 @@ int bkz(Options& o, IntMatrix& b) {
     param.dumpGSOFilename = o.bkzDumpGSOFilename;
   if (o.bkzFlags & BKZ_GH_BND)
     param.ghFactor = o.bkzGHFactor;
+  if (o.bkzFlags & BKZ_MAX_LOOPS)
+    param.maxLoops = o.bkzMaxLoops;
   if (o.verbose) param.flags |= BKZ_VERBOSE;
   if (o.noLLL) param.flags |= BKZ_NO_LLL;
   if (o.pruningFile != NULL) {

--- a/src/main.h
+++ b/src/main.h
@@ -40,7 +40,8 @@ struct Options {
   Options() : action(ACTION_LLL), method(LM_WRAPPER), intType(ZT_MPZ),
               floatType(FT_DEFAULT), delta(LLL_DEF_DELTA), eta(LLL_DEF_ETA),
               precision(0), earlyRed(false), siegel(false), noLLL(false),
-              blockSize(0), preprocBlockSize(2), verbose(false), inputFile(NULL),
+              blockSize(0), preprocBlockSize(2), bkzLinearPruningLevel(0),
+              bkzGHFactor(1.1), verbose(false), inputFile(NULL),
               outputFormat(NULL), pruningFile(NULL) {
     bkzFlags = 0;
     bkzMaxLoops = 0;
@@ -64,6 +65,7 @@ struct Options {
   double bkzMaxTime;
   string bkzDumpGSOFilename;
   int bkzLinearPruningLevel;
+  double bkzGHFactor;  
 
   bool verbose;
   const char* inputFile;

--- a/src/nr.cpp
+++ b/src/nr.cpp
@@ -1188,6 +1188,13 @@ inline void FP_NR<dpe_t>::log(const FP_NR<dpe_t>& a, mp_rnd_t /*rnd*/) {
 }
 
 template<>
+inline void FP_NR<dpe_t>::exponential(const FP_NR<dpe_t>& a, mp_rnd_t /*rnd*/) {
+  dpe_ugly_exp(data, a.data);
+  /*  FPLLL_DEBUG_ABORT("FP_NR<dpe_t>::exp not implemented"); */
+}
+
+
+template<>
 inline int FP_NR<dpe_t>::cmp(const FP_NR<dpe_t>& a) const {
   return dpe_cmp(data, a.data);
 }

--- a/src/svpcvp.cpp
+++ b/src/svpcvp.cpp
@@ -151,11 +151,11 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
   }
   evaluator->initDeltaDef(prec, rho, true);
 
-  if (evalMode == EVALMODE_SV || method == SVPM_PROVED) {
+  if (!(flags & SVP_OVERRIDE_BND) && (evalMode == EVALMODE_SV || method == SVPM_PROVED)) {
     Float ftmp1;
     bool result = evaluator->getMaxErrorAux(maxDist, true, ftmp1);
     FPLLL_CHECK(result, "shortestVector: cannot compute an initial bound");
-    if(!(flags & SVP_OVERRIDE_BND)) maxDist.add(maxDist, ftmp1, GMP_RNDU);
+    maxDist.add(maxDist, ftmp1, GMP_RNDU);
   }
   
   // Main loop of the enumeration

--- a/src/svpcvp.cpp
+++ b/src/svpcvp.cpp
@@ -122,7 +122,7 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
     d = newD;
   }
 
-  if (evalMode == EVALMODE_SV) {
+  if (evalMode == EVALMODE_SV && !(flags & SVP_OVERRIDE_BND)) {
     /* Computes a bound for the enumeration. This bound would work for an
        exact algorithm, but we will increase it later to ensure that the fp
        algorithm finds a solution */
@@ -155,9 +155,9 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
     Float ftmp1;
     bool result = evaluator->getMaxErrorAux(maxDist, true, ftmp1);
     FPLLL_CHECK(result, "shortestVector: cannot compute an initial bound");
-    maxDist.add(maxDist, ftmp1, GMP_RNDU);
+    if(!(flags & SVP_OVERRIDE_BND)) maxDist.add(maxDist, ftmp1, GMP_RNDU);
   }
-
+  
   // Main loop of the enumeration
   enumerateSVP(d, gso, maxDist, *evaluator, pruning, flags);
 
@@ -190,10 +190,10 @@ int shortestVector(IntMatrix& b, IntVect& solCoord,
 }
 
 int shortestVectorPruning(IntMatrix& b, IntVect& solCoord,
-                   const vector<double>& pruning, int flags) {
+                   const vector<double>& pruning, Integer& argIntMaxDist, int flags) {
   long long tmp;
   return shortestVectorEx(b, solCoord, SVPM_FAST, pruning, flags,
-          EVALMODE_SV, Integer(), tmp);
+          EVALMODE_SV, argIntMaxDist, tmp);
 }
 
 long long countShortVectors(IntMatrix& b, const Integer& maxSqrNorm,

--- a/src/svpcvp.h
+++ b/src/svpcvp.h
@@ -32,7 +32,7 @@ int shortestVector(IntMatrix& b, IntVect& solCoord,
         SVPMethod method = SVPM_PROVED, int flags = SVP_DEFAULT);
 
 int shortestVectorPruning(IntMatrix& b, IntVect& solCoord,
-        const vector<double>& pruning, int flags = SVP_DEFAULT);
+        const vector<double>& pruning, Integer& argIntMaxDist, int flags = SVP_DEFAULT);
 
 // Experimental. Do not use.
 int closestVector(IntMatrix& b, const IntVect& intTarget,


### PR DESCRIPTION
Rebasing screwed up my commit chain so I have recreated this pull request. 

It adds the possibility of using the Gaussian Heuristic enumeration bound in BKZ with the BKZ_GH_BND flag and the ghFactor parameter or the -bkzghbound command with a ghFactor. BKZ will then use ghFactor*GH^2 as its enumeration bound instead of the usual (length of the current shortest vector), but only if the block size of the enumeration is bigger than 30. If a vector is not found during the enumeration, the current vector is kept and it continues with the next index. Note that this is a heuristic, and BKZ-reducedness will no longer be guaranteed. In order to compute the GH value it uses the exponential function which was not properly implemented for dpe, so I added a hack fix to dpe.h (and nr.cpp/nr.h), similar to how the log function was "fixed" for dpe.

Note that this heuristic will mostly be useful when used in conjunction with pruning on high block sizes, but here is some experimental result: On an 80-dimensional GM lattice it takes about 46 seconds to do 5 rounds of BKZ without the heuristic and 36 seconds with the heuristic on my machine. The output GSO is slightly worse with the heuristic due to missed vectors. Again, though, the effect will be much more noticeable with higher BKZ block size, but it is not as feasible to test this without pruning. 

For SVP it adds an SVP_OVERRIDE_BND flag, which can be used with the shortestVectorPruning function to choose your own bound which does not get the added error term of other SVP calls. This allows you to implement some extreme pruning enumeration with your own bound. 

Additionally, I fixed a bug where bkzlinearpruning was not initialized and one where the bkzmaxloops value was not passed on to BKZ, rendering the command useless. 