### PR TITLE
Generating random numbers for Z_NR

### DIFF
--- a/src/nr.cpp
+++ b/src/nr.cpp
@@ -210,6 +210,27 @@ inline long Z_NR<long>::exponent() const {
 }
 
 template<>
+inline void Z_NR<long>::randb(int bits) {
+  mpz_t temp;
+  mpz_init(temp);
+  mpz_urandomb(temp, RandGen::getGMPState(), bits);
+  data = mpz_get_si(temp);
+  mpz_clear(temp);
+}
+
+template<>
+inline void Z_NR<long>::randm(const Z_NR<long>& max) {
+  mpz_t temp, lim;
+  mpz_init(temp);
+  mpz_init(lim);
+  mpz_set_si(lim, max.data);
+  mpz_urandomm(temp, RandGen::getGMPState(), lim);
+  data = mpz_get_si(temp);
+  mpz_clear(temp);
+  mpz_clear(lim);
+}
+
+template<>
 inline void Z_NR<long>::swap(Z_NR<long>& a) {
   std::swap(data, a.data);
 }
@@ -430,6 +451,28 @@ inline long Z_NR<double>::exponent() const {
   frexp(data, &intExpo);
   return static_cast<long>(intExpo);
 }
+
+template<>
+inline void Z_NR<double>::randb(int bits) {
+  mpz_t temp;
+  mpz_init(temp);
+  mpz_urandomb(temp, RandGen::getGMPState(), bits);
+  data = mpz_get_d(temp);
+  mpz_clear(temp);
+}
+
+template<>
+inline void Z_NR<double>::randm(const Z_NR<double>& max) {
+  mpz_t temp, lim;
+  mpz_init(temp);
+  mpz_init(lim);
+  mpz_set_d(lim, max.data);
+  mpz_urandomm(temp, RandGen::getGMPState(), lim);
+  data = mpz_get_d(temp);
+  mpz_clear(temp);
+  mpz_clear(lim);
+}
+
 template<>
 inline void Z_NR<double>::swap(Z_NR<double>& a) {
   std::swap(data, a.data);

--- a/src/nr.h
+++ b/src/nr.h
@@ -178,8 +178,12 @@ public:
   inline void abs(const Z_NR<Z>& a);
   /** Returns the smallest non-negative expo such that |value| < 2^expo. */
   inline long exponent() const;
+  
+  /** Generates random integer between 0 and 2^n-1. */
   inline void randb(int bits);
+  /** Generates random integer between 0 and n - 1  */
   inline void randm(const Z_NR<Z>& max);
+
   inline bool is_zero() const {return *this == 0;}
 
   /** Efficiently swaps the values of two Z_NR. */


### PR DESCRIPTION
Currently, random number generation works for Z_NR class only when the data type is mpz_t.
Have added methods to generate random numbers for types long and double using random number functions of GMP.