### PR TITLE
dual enumeration

### DIFF
--- a/src/bkz.cpp
+++ b/src/bkz.cpp
@@ -93,9 +93,9 @@ bool BKZReduction<FT>::svpReduction(int kappa, int blockSize, const BKZParam &pa
     double cputimeStart2 = cputime();
 
     for(int i=0; ; i++) {
-      if ((par.flags & BKZ_MAX_LOOPS) && i >= par.maxLoops) break;
-      if ((par.flags & BKZ_MAX_TIME) && (cputime() - cputimeStart2) * 0.001 >= par.maxTime) break;
-      if (autoAbort.testAbort(par.autoAbort_scale, par.autoAbort_maxNoDec)) break;
+      if ((preproc->flags & BKZ_MAX_LOOPS) && i >= preproc->maxLoops) break;
+      if ((preproc->flags & BKZ_MAX_TIME) && (cputime() - cputimeStart2) * 0.001 >= preproc->maxTime) break;
+      if (autoAbort.testAbort(preproc->autoAbort_scale, preproc->autoAbort_maxNoDec)) break;
 
       bool clean2 = true;
       if (!bkzLoop(i, dummyKappaMax, *preproc, kappa, kappa + blockSize, clean2))

--- a/src/defs.h
+++ b/src/defs.h
@@ -190,7 +190,8 @@ enum SVPMethod {
 
 enum SVPFlags {
   SVP_DEFAULT = 0,
-  SVP_VERBOSE = 1
+  SVP_VERBOSE = 1,
+  SVP_DUAL = 2
 };
 
 enum CVPFlags {

--- a/src/enumerate.cpp
+++ b/src/enumerate.cpp
@@ -1,4 +1,5 @@
-/* Copyright (C) 2008-2011 Xavier Pujol.
+/* Copyright (C) 2008-2011 Xavier Pujol
+   (C) 2015 Michael Walter.
 
    This file is part of fplll. fplll is free software: you
    can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -28,10 +29,13 @@ EnumfVect Enumeration::center;
 EnumfVect Enumeration::centerPartSum;
 EnumfVect Enumeration::maxDists;
 EnumfVect Enumeration::centerLoopBg;
+EnumfVect Enumeration::alpha;
 int Enumeration::d;
 int Enumeration::k;
 int Enumeration::kEnd;
 int Enumeration::kMax;
+bool Enumeration::dual;
+Z_NR<mpz_t> Enumeration::nodes;
 
 static const vector<FP_NR<double> > EMPTY_DOUBLE_VECT;
 
@@ -47,7 +51,7 @@ void Enumeration::prepareEnumeration(enumf maxDist, const vector<FT>& subTree, b
   for (k = d - 1; k >= 0 && newDist <= maxDist; k--) {
     enumf newCenter = centerPartSum[k];
     for (int j = k + 1; j < kEnd; j++) {
-      newCenter -= x[j] * mut[k][j];
+      newCenter += center_summand(k, j);
     }
 
     if (k >= kEnd) {
@@ -68,8 +72,8 @@ void Enumeration::prepareEnumeration(enumf maxDist, const vector<FT>& subTree, b
               << " ddx_k=" << ddx[k]);*/
     }
     x[k] = newX;
-    enumf y = newCenter - newX;
-    newDist += y * y * rdiag[k];
+    alpha[k] = newX - newCenter;
+    newDist += alpha[k] * alpha[k] * rdiag[k];
   }
   if (!svpBeginning) {
     kMax = kEnd; // The last non-zero coordinate of x will not stay positive
@@ -94,13 +98,14 @@ bool Enumeration::enumerateLoop(enumf& newMaxDist, int& newKMax) {
   }
 
   while (true) {
-    enumf y = center[k] - x[k];
-    enumf newDist = dist[k] + y * y * rdiag[k];
+    alpha[k] = x[k] - center[k];
+    enumf newDist = dist[k] + alpha[k] * alpha[k] * rdiag[k];
     /*FPLLL_TRACE("k=" << k << " x_k=" << x[k] << " center_k=" << center[k]
             << " dist_k=" << dist[k] << " r_k=" << rdiag[k]
             << " y=" << y << " newDist=" << newDist);*/
     if (newDist <= maxDists[k]) {
       k--;
+      nodes.add_ui(nodes, 1);
       if (k < 0) {
         newMaxDist = newDist;
         newKMax = kMax;
@@ -108,7 +113,8 @@ bool Enumeration::enumerateLoop(enumf& newMaxDist, int& newKMax) {
       }
 
       for (int j = centerLoopBg[k]; j > k; j--) {
-        centerPartSums[k][j] = centerPartSums[k][j + 1] - x[j] * mut[k][j];
+        //~ centerPartSums[k][j] = centerPartSums[k][j + 1] - x[j] * mut[k][j];
+        centerPartSums[k][j] = centerPartSums[k][j + 1] + center_summand(k, j);
       }
       enumf newCenter = centerPartSums[k][k + 1];
       if (k > 0) centerLoopBg[k - 1] = max(centerLoopBg[k - 1], centerLoopBg[k]);
@@ -165,8 +171,9 @@ template<class FT>
 void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDistExpo,
                Evaluator<FT>& evaluator, const vector<FT>& targetCoord,
                const vector<FT>& subTree, int first, int last,
-               const vector<double>& pruning) {
+               const vector<double>& pruning, bool dual) {
   bool solvingSVP;    // true->SVP, false->CVP
+  Enumeration::dual = dual;
   enumf maxDist;
   FT fR, fMu, fMaxDistNorm;
   long rExpo, normExp = LONG_MIN;
@@ -177,6 +184,9 @@ void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDist
   solvingSVP = targetCoord.empty();
   FPLLL_CHECK(d <= DMAX, "enumerate: dimension is too high");
 
+  FPLLL_CHECK((solvingSVP || !dual), "CVP for dual not implemented! What does that even mean? ");
+  FPLLL_CHECK((subTree.empty() || !dual), "Subtree enumeration for dual not implemented!");
+
   // FT->enumf conversion and transposition of mu
   for (int i = 0; i < d; i++) {
     fR = gso.getRExp(i + first, i + first, rExpo);
@@ -185,11 +195,16 @@ void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDist
 
   fMaxDistNorm.mul_2si(fMaxDist, maxDistExpo - normExp);
   maxDist = fMaxDistNorm.get_d(GMP_RNDU);
+  if (dual) maxDist = enumf(1.0)/maxDist;
 
   for (int i = 0; i < d; i++) {
     fR = gso.getRExp(i + first, i + first, rExpo);
     fR.mul_2si(fR, rExpo - normExp);
-    rdiag[i] = fR.get_d();
+    if (dual) {
+      rdiag[d-i-1] = enumf(1.0)/fR.get_d();
+    } else {
+      rdiag[i] = fR.get_d();
+    }
 
     if (solvingSVP)
       centerPartSum[i] = 0.0;
@@ -198,15 +213,21 @@ void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDist
 
     for (int j = i + 1; j < d; j++) {
       gso.getMu(fMu, j + first, i + first);
-      mut[i][j] = fMu.get_d();
+      if (dual) {
+        mut[j][i] = fMu.get_d();
+      } else {
+        mut[i][j] = fMu.get_d();
+      }
     }
   }
 
   prepareEnumeration(maxDist, subTree, solvingSVP);
   enumerate(maxDist, normExp, evaluator, pruning);
-
-  fMaxDistNorm = maxDist; // Exact
+  
+  fMaxDistNorm = dual ? enumf(1.0)/maxDist : maxDist; // Exact
   fMaxDist.mul_2si(fMaxDistNorm, normExp - maxDistExpo);
+  
+  if (dual && !evaluator.solCoord.empty()) reverseBySwap(evaluator.solCoord, 0, d-1);
 }
 
 

--- a/src/enumerate.cpp
+++ b/src/enumerate.cpp
@@ -192,10 +192,13 @@ void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDist
     fR = gso.getRExp(i + first, i + first, rExpo);
     normExp = max(normExp, rExpo + fR.exponent());
   }
-
-  fMaxDistNorm.mul_2si(fMaxDist, maxDistExpo - normExp);
+  
+  if (dual) {
+    fMaxDistNorm.mul_2si(fMaxDist, normExp - maxDistExpo);
+  } else {
+    fMaxDistNorm.mul_2si(fMaxDist, maxDistExpo - normExp);
+  }
   maxDist = fMaxDistNorm.get_d(GMP_RNDU);
-  if (dual) maxDist = enumf(1.0)/maxDist;
 
   for (int i = 0; i < d; i++) {
     fR = gso.getRExp(i + first, i + first, rExpo);

--- a/src/enumerate.h
+++ b/src/enumerate.h
@@ -1,4 +1,5 @@
-/* Copyright (C) 2008-2011 Xavier Pujol.
+/* Copyright (C) 2008-2011 Xavier Pujol
+   (C) 2015 Michael Walter.
 
    This file is part of fplll. fplll is free software: you
    can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -33,17 +34,20 @@ public:
   static void enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDistExpo,
                Evaluator<FT>& evaluator, const vector<FT>& targetCoord,
                const vector<FT>& subTree, int first, int last,
-               const vector<double>& pruning);
-
+               const vector<double>& pruning, bool dual = false);
+  
+  static Z_NR<mpz_t> nodes;
+  
 private:
   static const int DMAX = 150;
   static enumf mut[DMAX][DMAX];
   static enumf centerPartSums[DMAX][DMAX + 1];
-  static EnumfVect rdiag, x, dx, ddx, dist, center, centerPartSum, maxDists, centerLoopBg;
+  static EnumfVect rdiag, x, dx, ddx, dist, center, centerPartSum, maxDists, centerLoopBg, alpha;
   static int d;
   static int k;              // Current level in the enumeration
   static int kEnd;           // The algorithm stops when k = kEnd
   static int kMax;           // Index of the last non-zero value of x (<= kEnd)
+  static bool dual;
 
   // Input: x, dx, ddx, k, kMax, kEnd
   // Output: k, kMax
@@ -66,6 +70,10 @@ private:
       result = false;
     }
     return result;
+  }
+
+  static inline enumf center_summand(int k, int j) {
+    return dual ? alpha[j] * mut[d-k-1][d-j-1] : - x[j] * mut[k][j];
   }
 
   template<class FT>

--- a/src/enumerate.h
+++ b/src/enumerate.h
@@ -41,7 +41,6 @@ private:
   static enumf mut[DMAX][DMAX];
   static enumf centerPartSums[DMAX][DMAX + 1];
   static EnumfVect rdiag, x, dx, ddx, dist, center, centerPartSum, maxDists, centerLoopBg, alpha;
-  static EnumfVect *co;
   static int d;
   static int k;              // Current level in the enumeration
   static int kEnd;           // The algorithm stops when k = kEnd
@@ -74,6 +73,7 @@ private:
   template<class FT>
   static void prepareEnumeration(enumf maxDist, const vector<FT>& subTree, bool solvingSVP);
   
+  template<class EnumType>
   static bool enumerateLoop(enumf& newMaxDist, int& newKMax);
 
   template<class FT>
@@ -81,6 +81,19 @@ private:
   
 };
 
+class PrimalEnum {
+  public:
+    static enumf& center_summand_coefficient(enumf& alpha, enumf& x) {
+      return x;
+    }
+};
+
+class DualEnum {
+  public:
+    static enumf& center_summand_coefficient(enumf& alpha, enumf& x) {
+      return alpha;
+    }
+};
 
 FPLLL_END_NAMESPACE
 

--- a/src/enumerate.h
+++ b/src/enumerate.h
@@ -41,6 +41,7 @@ private:
   static enumf mut[DMAX][DMAX];
   static enumf centerPartSums[DMAX][DMAX + 1];
   static EnumfVect rdiag, x, dx, ddx, dist, center, centerPartSum, maxDists, centerLoopBg, alpha;
+  static EnumfVect *co;
   static int d;
   static int k;              // Current level in the enumeration
   static int kEnd;           // The algorithm stops when k = kEnd
@@ -72,12 +73,14 @@ private:
 
   template<class FT>
   static void prepareEnumeration(enumf maxDist, const vector<FT>& subTree, bool solvingSVP);
-
+  
   static bool enumerateLoop(enumf& newMaxDist, int& newKMax);
 
   template<class FT>
   static void enumerate(enumf& maxDist, long normExp, Evaluator<FT>& evaluator, const vector<double>& pruning);
+  
 };
+
 
 FPLLL_END_NAMESPACE
 

--- a/src/enumerate.h
+++ b/src/enumerate.h
@@ -36,8 +36,6 @@ public:
                const vector<FT>& subTree, int first, int last,
                const vector<double>& pruning, bool dual = false);
   
-  static Z_NR<mpz_t> nodes;
-  
 private:
   static const int DMAX = 150;
   static enumf mut[DMAX][DMAX];
@@ -70,10 +68,6 @@ private:
       result = false;
     }
     return result;
-  }
-
-  static inline enumf center_summand(int k, int j) {
-    return dual ? alpha[j] * mut[d-k-1][d-j-1] : - x[j] * mut[k][j];
   }
 
   template<class FT>

--- a/src/svpcvp.cpp
+++ b/src/svpcvp.cpp
@@ -55,9 +55,10 @@ static void getBasisMin(Integer& basisMin, const IntMatrix& b,
 static bool enumerateSVP(int d, MatGSO<Integer, Float>& gso, Float& maxDist,
         Evaluator<Float>& evaluator, const vector<double>& pruning,
         int flags) {
-  if (d == 1 || !pruning.empty()) {
+  bool dual = (flags & SVP_DUAL);
+  if (d == 1 || !pruning.empty() || dual) {
     Enumeration::enumerate(gso, maxDist, 0, evaluator, FloatVect(), FloatVect(),
-            0, d, pruning);
+            0, d, pruning, dual);
   }
   else {
     Enumerator enumerator(d, gso.getMuMatrix(), gso.getRMatrix());
@@ -121,18 +122,27 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
     //FPLLL_TRACE("Ignoring the last " << d - newD << " vector(s)");
     d = newD;
   }
-
-  if (evalMode == EVALMODE_SV) {
-    /* Computes a bound for the enumeration. This bound would work for an
-       exact algorithm, but we will increase it later to ensure that the fp
-       algorithm finds a solution */
-    getBasisMin(intMaxDist, b, 0, d);
+  
+  if (flags & SVP_DUAL) {
+    maxDist = gso.getRExp(d - 1, d - 1);
+    Float one; one = 1.0;
+    maxDist.div(one, maxDist);
+    if (flags & SVP_VERBOSE) {
+      cout << "maxDist = " << maxDist << endl;
+    }
+  } else {
+    if (evalMode == EVALMODE_SV) {
+      /* Computes a bound for the enumeration. This bound would work for an
+         exact algorithm, but we will increase it later to ensure that the fp
+         algorithm finds a solution */
+      getBasisMin(intMaxDist, b, 0, d);
+    }
+    else {
+      /* Use the bound given as a parameter */
+      intMaxDist = argIntMaxDist;
+    }
+    maxDist.set_z(intMaxDist, GMP_RNDU);
   }
-  else {
-    /* Use the bound given as a parameter */
-    intMaxDist = argIntMaxDist;
-  }
-  maxDist.set_z(intMaxDist, GMP_RNDU);
 
   // Initializes the evaluator of solutions
   Evaluator<Float>* evaluator;
@@ -155,7 +165,11 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
     Float ftmp1;
     bool result = evaluator->getMaxErrorAux(maxDist, true, ftmp1);
     FPLLL_CHECK(result, "shortestVector: cannot compute an initial bound");
-    maxDist.add(maxDist, ftmp1, GMP_RNDU);
+    if (flags & SVP_DUAL) {
+      maxDist.add(maxDist, ftmp1, GMP_RNDU);
+    } else {
+      maxDist.sub(maxDist, ftmp1, GMP_RNDU);
+    }
   }
 
   // Main loop of the enumeration

--- a/src/svpcvp.cpp
+++ b/src/svpcvp.cpp
@@ -165,11 +165,7 @@ static int shortestVectorEx(IntMatrix& b, IntVect& solCoord,
     Float ftmp1;
     bool result = evaluator->getMaxErrorAux(maxDist, true, ftmp1);
     FPLLL_CHECK(result, "shortestVector: cannot compute an initial bound");
-    if (flags & SVP_DUAL) {
-      maxDist.add(maxDist, ftmp1, GMP_RNDU);
-    } else {
-      maxDist.sub(maxDist, ftmp1, GMP_RNDU);
-    }
+    maxDist.add(maxDist, ftmp1, GMP_RNDU);
   }
   
   // Main loop of the enumeration


### PR DESCRIPTION
This adds the ability to enumerate shortest vectors in the dual instead of the primal to the Enumeration class. For details on the dual enumeration algorithm, see http://eprint.iacr.org/2015/1123. 

Access to the new enumeration is provided through the shortestVector function (in svpcvp.cpp) and a new flag: SVP_DUAL.