### PR TITLE
Minor tweak to get it building on cygwin.

### DIFF
--- a/src/fplll.cpp
+++ b/src/fplll.cpp
@@ -422,7 +422,9 @@ const char* getRedStatusStr(int status) {
 }
 
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<double> >(MatGSO<Z_NR<mpz_t>, FP_NR<double> >& m, double delta, double eta);
+#ifdef FPLLL_WITH_LONG_DOUBLE
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<long double> >(MatGSO<Z_NR<mpz_t>, FP_NR<long double> >& m, double delta, double eta);
+#endif
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<mpfr_t> >(MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >& m, double delta, double eta);
 
 #ifdef FPLLL_WITH_QD


### PR DESCRIPTION
All the long double templates are disabled for cygwin, but one template instantiation
in fplll.cpp wasn't guarded. Previously failed with:
  .libs/fplll.o:fplll.cpp(.text$_ZN5fplll6MatGSOINS_4Z_NRIA1_12__mpz_structEENS_5FP_NRIeEEE12updateGSORowEii[_ZN5fplll6MatGSOINS_4Z_NRIA1_12__mpz_structEENS_5FP_NRIeEEE12updateGSORowEii]+0xba): undefined reference to `fplll::FP_NR<long double>::is_nan() const'

and multiple other missing definitions for FP_NR<long double>.

I added an #ifdef guard to disable that one too.

I haven't tried the fix on any other platforms, only cygwin.