### PR TITLE
bugfix in the dual enumeration

### DIFF
--- a/src/enumerate.cpp
+++ b/src/enumerate.cpp
@@ -237,7 +237,7 @@ void Enumeration::enumerate(MatGSO<Integer, FT>& gso, FT& fMaxDist, long maxDist
   fMaxDistNorm = maxDist; // Exact
   
   if (dual) {
-    fMaxDistNorm.mul_2si(fMaxDist, maxDistExpo - normExp);
+    fMaxDist.mul_2si(fMaxDistNorm, maxDistExpo - normExp);
   } else {
     fMaxDist.mul_2si(fMaxDistNorm, normExp - maxDistExpo);
   }


### PR DESCRIPTION
After the dual enumeration completed, the maxDist norm was not updated correctly. So the function worked and returned a shortest dual vector, but the maxDist variable still contained the old value. 