### PR TITLE
Fixes for fplll as a library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@ include_fplll_HEADERS=defs.h dpe.h fplll.h matrix.h matrix.cpp \
 	nr_Z_misc.inl \
 	nr_Z_mpz.inl \
 	numvect.h util.h svpcvp.h fplllv31.h bkz.h lll.h gso.h evaluator.h \
-	fplll_config.h
+	fplll_config.h wrapper.h enumerate.h
 
 EXTRA_DIST=pruning.txt
 

--- a/src/bkz.cpp
+++ b/src/bkz.cpp
@@ -48,7 +48,7 @@ BKZReduction<FT>::~BKZReduction() {
 }
 
 template<class FT>
-static double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow) {
+double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow) {
   FT f, logF;
   long expo;
   vector<double> x;
@@ -73,7 +73,7 @@ static double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow)
 }
 
 template<class FT>
-static void computeGaussHeurDist(MatGSO<Integer, FT>& m, FT& maxDist, long maxDistExpo, int kappa, int blockSize, double ghFactor){
+void computeGaussHeurDist(MatGSO<Integer, FT>& m, FT& maxDist, long maxDistExpo, int kappa, int blockSize, double ghFactor){
   double t = (double)blockSize/2.0+1;
   t=tgamma(t);
   t=pow(t,2.0/(double)blockSize);

--- a/src/bkz.h
+++ b/src/bkz.h
@@ -112,13 +112,13 @@ public:
     LLL-reduced basis.
 */
 template<class FT>
-static double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow);
+double getCurrentSlope(MatGSO<Integer, FT>& m, int startRow, int stopRow);
 
 /** Uses the Gaussian Heuristic Distance to compute a bound on the length of the
     shortest vector.
 */
 template<class FT>
-static void computeGaussHeurDist(MatGSO<Integer, FT>& m, FT& maxDist, long maxDistExpo, int kappa, int blockSize, double ghFactor);
+void computeGaussHeurDist(MatGSO<Integer, FT>& m, FT& maxDist, long maxDistExpo, int kappa, int blockSize, double ghFactor);
 
 /* The matrix must be LLL-reduced */
 template<class FT>

--- a/src/fplll.cpp
+++ b/src/fplll.cpp
@@ -421,6 +421,8 @@ const char* getRedStatusStr(int status) {
     return "unknown error";
 }
 
+/** instantiate functions **/
+
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<double> >(MatGSO<Z_NR<mpz_t>, FP_NR<double> >& m, double delta, double eta);
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<long double> >(MatGSO<Z_NR<mpz_t>, FP_NR<long double> >& m, double delta, double eta);
@@ -435,5 +437,12 @@ template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<qd_real> >(MatGSO<Z_NR<mpz_t>, FP_
 #ifdef FPLLL_WITH_DPE
 template bool isLLLReduced<Z_NR<mpz_t>, FP_NR<dpe_t> >(MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >& m, double delta, double eta);
 #endif
+
+template void Enumeration::enumerate<FP_NR<double> >(MatGSO<Integer, FP_NR<double> >& gso,
+                                                     FP_NR<double>& fMaxDist, long maxDistExpo,
+                                                     Evaluator<FP_NR<double> >& evaluator,
+                                                     const vector<FP_NR<double> >& targetCoord,
+                                                     const vector<FP_NR<double> >& subTree,
+                                                     int first, int last, const vector<double>& pruning, bool dual);
 
 FPLLL_END_NAMESPACE

--- a/src/lll.cpp
+++ b/src/lll.cpp
@@ -145,16 +145,6 @@ bool LLLReduction<ZT, FT>::lll(int kappaMin, int kappaStart, int kappaEnd) {
 }
 
 template<class ZT, class FT>
-bool LLLReduction<ZT, FT>::sizeReduction(int kappaMin, int kappaEnd) {
-  if (kappaEnd == -1) kappaEnd = m.d;
-  for (int k = kappaMin; k < kappaEnd; k++) {
-    if ((k > 0 && !babai(k, k)) || !m.updateGSORow(k))
-      return false;
-  }
-  return setStatus(RED_SUCCESS);
-}
-
-template<class ZT, class FT>
 bool LLLReduction<ZT, FT>::babai(int kappa, int nCols) {
   //FPLLL_TRACE_IN("kappa=" << kappa);
   long maxExpo = LONG_MAX;

--- a/src/lll.cpp
+++ b/src/lll.cpp
@@ -194,46 +194,6 @@ bool LLLReduction<ZT, FT>::babai(int kappa, int nCols) {
 }
 
 template<class ZT, class FT>
-bool LLLReduction<ZT, FT>::earlyReduction(int start) {
-  m.lockCols();
-  if (verbose) {
-    cerr << "Early reduction start=" << start + 1 << endl;
-  }
-  for (int i = start; i < m.d; i++) {
-    if (!babai(i, start)) return false;
-  }
-  m.unlockCols();
-  lastEarlyRed = start;
-  return true;
-}
-
-template<class ZT, class FT>
-void LLLReduction<ZT, FT>::printParams() {
-  cerr << "Entering LLL"
-       << "\ndelta = " << delta
-       << "\neta = " << eta
-       << "\nprecision = " << FT::getprec()
-       << "\nexact_dot_product = " << static_cast<int>(m.enableIntGram)
-       << "\nrow_expo = " << static_cast<int>(m.enableRowExpo)
-       << "\nearly_red = " << static_cast<int>(enableEarlyRed)
-       << "\nsiegel_cond = " << static_cast<int>(siegel)
-       << "\nlong_in_babai = " << static_cast<int>(m.rowOpForceLong) << endl;
-}
-
-template<class ZT, class FT>
-bool LLLReduction<ZT, FT>::setStatus(int newStatus) {
-  status = newStatus;
-  if (verbose) {
-    if (status == RED_SUCCESS)
-      cerr << "End of LLL: success" << endl;
-    else
-      cerr << "End of LLL: failure: " << RED_STATUS_STR[status] << endl;
-  }
-  return status == RED_SUCCESS;
-}
-
-
-template<class ZT, class FT>
 bool isLLLReduced(MatGSO<ZT, FT>& m, double delta, double eta) {
   FT ftmp1;
   FT ftmp2;
@@ -263,6 +223,5 @@ bool isLLLReduced(MatGSO<ZT, FT>& m, double delta, double eta) {
   }
   return true;
 }
-
 
 FPLLL_END_NAMESPACE

--- a/src/lll.h
+++ b/src/lll.h
@@ -48,9 +48,9 @@ public:
 
 private:
   bool babai(int kappa, int nCols);
-  bool earlyReduction(int start);
-  void printParams();
-  bool setStatus(int newStatus);
+  inline bool earlyReduction(int start);
+  inline void printParams();
+  inline bool setStatus(int newStatus);
 
   MatGSO<ZT, FT>& m;
   FT delta, eta, swapThreshold;
@@ -78,6 +78,46 @@ inline bool LLLReduction<ZT, FT>::sizeReduction(int kappaMin, int kappaEnd) {
   }
   return setStatus(RED_SUCCESS);
 }
+
+template<class ZT, class FT>
+inline bool LLLReduction<ZT, FT>::earlyReduction(int start) {
+  m.lockCols();
+  if (verbose) {
+    cerr << "Early reduction start=" << start + 1 << endl;
+  }
+  for (int i = start; i < m.d; i++) {
+    if (!babai(i, start)) return false;
+  }
+  m.unlockCols();
+  lastEarlyRed = start;
+  return true;
+}
+
+template<class ZT, class FT>
+inline void LLLReduction<ZT, FT>::printParams() {
+  cerr << "Entering LLL"
+       << "\ndelta = " << delta
+       << "\neta = " << eta
+       << "\nprecision = " << FT::getprec()
+       << "\nexact_dot_product = " << static_cast<int>(m.enableIntGram)
+       << "\nrow_expo = " << static_cast<int>(m.enableRowExpo)
+       << "\nearly_red = " << static_cast<int>(enableEarlyRed)
+       << "\nsiegel_cond = " << static_cast<int>(siegel)
+       << "\nlong_in_babai = " << static_cast<int>(m.rowOpForceLong) << endl;
+}
+
+template<class ZT, class FT>
+inline bool LLLReduction<ZT, FT>::setStatus(int newStatus) {
+  status = newStatus;
+  if (verbose) {
+    if (status == RED_SUCCESS)
+      cerr << "End of LLL: success" << endl;
+    else
+      cerr << "End of LLL: failure: " << RED_STATUS_STR[status] << endl;
+  }
+  return status == RED_SUCCESS;
+}
+
 
 FPLLL_END_NAMESPACE
 

--- a/src/lll.h
+++ b/src/lll.h
@@ -38,7 +38,7 @@ public:
                int flags);
 
   bool lll(int kappaMin = 0, int kappaStart = 0, int kappaEnd = -1);
-  bool sizeReduction(int kappaMin = 0, int kappaEnd = -1);
+  inline bool sizeReduction(int kappaMin = 0, int kappaEnd = -1);
 
   int status;
   int finalKappa;
@@ -68,6 +68,16 @@ private:
 
 template<class ZT, class FT>
 bool isLLLReduced(MatGSO<ZT, FT>& m, double delta, double eta);
+
+template<class ZT, class FT>
+inline bool LLLReduction<ZT, FT>::sizeReduction(int kappaMin, int kappaEnd) {
+  if (kappaEnd == -1) kappaEnd = m.d;
+  for (int k = kappaMin; k < kappaEnd; k++) {
+    if ((k > 0 && !babai(k, k)) || !m.updateGSORow(k))
+      return false;
+  }
+  return setStatus(RED_SUCCESS);
+}
 
 FPLLL_END_NAMESPACE
 


### PR DESCRIPTION
The way we structure fplll means that not all member functions/methods are necessarily instantiated in the shared library, making it difficult to use fplll as a library for anything but the highlevel functions such as ```bkzReduction```. This pull requests inlines a few more helper function and installs a few more headers to make it easier to use lower-level functions from fplll as a third party. These fixes are required for [fpylll](https://github.com/malb/fpylll).