### PR TITLE
dump to double arrays

### DIFF
--- a/src/gso.h
+++ b/src/gso.h
@@ -271,6 +271,8 @@ public:
    * When a double pointer is provided the caller must ensure it can hold
    * blocksize^2 entries. When a vector is provided new entries are pushed to
    * the end. In particular, existing entries are not overwritten or cleared.
+   *
+   * @note No row discover or update is performed prior to dumping the matrix.
    */
 
   inline void dumpMu_d(double* mu, int offset=0, int blocksize=-1);
@@ -282,6 +284,8 @@ public:
    * When a double pointer is provided the caller must ensure it can hold
    * blocksize^2 entries. When a vector is provided new entries are pushed to
    * the end. In particular, existing entries are not overwritten or cleared.
+   *
+   * @note No row discover or update is performed prior to dumping the matrix.
    */
 
   inline void dumpR_d(double* r, int offset=0, int blocksize=-1);

--- a/src/gso.h
+++ b/src/gso.h
@@ -569,7 +569,7 @@ template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::dumpMu_d(double* mu, int offset, int blocksize){
   FT e;
   if (blocksize <= 0) {
-    blocksize = b.numRows();
+    blocksize = b.getRows();
   }
 
   for (int i = 0; i < blocksize; ++i) {
@@ -584,7 +584,7 @@ template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::dumpMu_d(vector<double> mu, int offset, int blocksize){
   FT e;
   if (blocksize <= 0) {
-    blocksize = b.numRows();
+    blocksize = b.getRows();
   }
 
   r.reserve(r.size() + blocksize*blocksize);
@@ -601,7 +601,7 @@ template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::dumpR_d(double* r, int offset, int blocksize){
   FT e;
   if (blocksize <= 0) {
-    blocksize = b.numRows();
+    blocksize = b.getRows();
   }
 
   for (int i = 0; i < blocksize; ++i) {
@@ -616,7 +616,7 @@ template<class ZT, class FT>
 inline void MatGSO<ZT, FT>::dumpR_d(vector<double> r, int offset, int blocksize){
   FT e;
   if (blocksize <= 0) {
-    blocksize = b.numRows();
+    blocksize = b.getRows();
   }
 
   r.reserve(r.size() + blocksize*blocksize);

--- a/src/gso.h
+++ b/src/gso.h
@@ -272,20 +272,20 @@ public:
    * blocksize^2 entries. When a vector is provided new entries are pushed to
    * the end. In particular, existing entries are not overwritten or cleared.
    *
-   * @note No row discover or update is performed prior to dumping the matrix.
+   * @note No row discovery or update is performed prior to dumping the matrix.
    */
 
   inline void dumpMu_d(double* mu, int offset=0, int blocksize=-1);
   inline void dumpMu_d(vector<double> mu, int offset=0, int blocksize=-1);
 
   /**
-   * Dump r matrix to parameter `r`.
+   * Dump r vector to parameter `r`.
 
    * When a double pointer is provided the caller must ensure it can hold
-   * blocksize^2 entries. When a vector is provided new entries are pushed to
-   * the end. In particular, existing entries are not overwritten or cleared.
+   * blocksize entries. When a vector is provided new entries are pushed to the
+   * end. In particular, existing entries are not overwritten or cleared.
    *
-   * @note No row discover or update is performed prior to dumping the matrix.
+   * @note No row discovery or update is performed prior to dumping the matrix.
    */
 
   inline void dumpR_d(double* r, int offset=0, int blocksize=-1);

--- a/src/gso.h
+++ b/src/gso.h
@@ -265,28 +265,6 @@ public:
     applyTransform(transform, srcBase, srcBase);
   }
 
-  /** Exact computation of dot products (i.e. with type ZT instead of FT) */
-  const bool enableIntGram;
-
-  /** Normalization of each row of b by a power of 2. */
-  const bool enableRowExpo;
-
-  /** Computation of the transform matrix. */
-  const bool enableTransform;
-
-  /**
-   * Computation of the inverse transform matrix (transposed).
-   * This works only if enableTransform=true.
-   * This matrix has very large coefficients, computing it is slow.
-   */
-  const bool enableInvTransform;
-
-  /**
-   * Changes the behaviour of row_addmul(_we).
-   * See the description of row_addmul.
-   */
-  const bool rowOpForceLong;
-
   /**
    * Dump mu matrix to parameter `mu`.
 
@@ -308,6 +286,28 @@ public:
 
   inline void dumpR_d(double* r, int offset=0, int blocksize=-1);
   inline void dumpR_d(vector<double> r, int offset=0, int blocksize=-1);
+
+  /** Exact computation of dot products (i.e. with type ZT instead of FT) */
+  const bool enableIntGram;
+
+  /** Normalization of each row of b by a power of 2. */
+  const bool enableRowExpo;
+
+  /** Computation of the transform matrix. */
+  const bool enableTransform;
+
+  /**
+   * Computation of the inverse transform matrix (transposed).
+   * This works only if enableTransform=true.
+   * This matrix has very large coefficients, computing it is slow.
+   */
+  const bool enableInvTransform;
+
+  /**
+   * Changes the behaviour of row_addmul(_we).
+   * See the description of row_addmul.
+   */
+  const bool rowOpForceLong;
 
 private:
   /* Allocates matrices and arrays whose size depends on d (all but tmpColExpo).

--- a/src/gso.h
+++ b/src/gso.h
@@ -287,6 +287,28 @@ public:
    */
   const bool rowOpForceLong;
 
+  /**
+   * Dump mu matrix to parameter `mu`.
+
+   * When a double pointer is provided the caller must ensure it can hold
+   * blocksize^2 entries. When a vector is provided new entries are pushed to
+   * the end. In particular, existing entries are not overwritten or cleared.
+   */
+
+  inline void dumpMu_d(double* mu, int offset=0, int blocksize=-1);
+  inline void dumpMu_d(vector<double> mu, int offset=0, int blocksize=-1);
+
+  /**
+   * Dump r matrix to parameter `r`.
+
+   * When a double pointer is provided the caller must ensure it can hold
+   * blocksize^2 entries. When a vector is provided new entries are pushed to
+   * the end. In particular, existing entries are not overwritten or cleared.
+   */
+
+  inline void dumpR_d(double* r, int offset=0, int blocksize=-1);
+  inline void dumpR_d(vector<double> r, int offset=0, int blocksize=-1);
+
 private:
   /* Allocates matrices and arrays whose size depends on d (all but tmpColExpo).
      When enableIntGram=false, initializes bf. */
@@ -541,6 +563,69 @@ inline void MatGSO<ZT, FT>::rowOpBegin(int first, int last) {
   rowOpFirst = first;
   rowOpLast = last;
 #endif
+}
+
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::dumpMu_d(double* mu, int offset, int blocksize){
+  FT e;
+  if (blocksize <= 0) {
+    blocksize = b.numRows();
+  }
+
+  for (int i = 0; i < blocksize; ++i) {
+    for (int j = 0; j < blocksize; ++j) {
+      getMu(e,offset+i,offset+j);
+      mu[i*blocksize+j] = e.get_d();
+    }
+  }
+}
+
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::dumpMu_d(vector<double> mu, int offset, int blocksize){
+  FT e;
+  if (blocksize <= 0) {
+    blocksize = b.numRows();
+  }
+
+  r.reserve(r.size() + blocksize*blocksize);
+  for (int i = 0; i < blocksize; ++i) {
+    for (int j = 0; j < blocksize; ++j) {
+      getMu(e,offset+i,offset+j);
+      mu.push_back(e.get_d());
+    }
+  }
+}
+
+
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::dumpR_d(double* r, int offset, int blocksize){
+  FT e;
+  if (blocksize <= 0) {
+    blocksize = b.numRows();
+  }
+
+  for (int i = 0; i < blocksize; ++i) {
+    for (int j = 0; j < blocksize; ++j) {
+      getR(e,offset+i,offset+j);
+      r[i*blocksize+j] = e.get_d();
+    }
+  }
+}
+
+template<class ZT, class FT>
+inline void MatGSO<ZT, FT>::dumpR_d(vector<double> r, int offset, int blocksize){
+  FT e;
+  if (blocksize <= 0) {
+    blocksize = b.numRows();
+  }
+
+  r.reserve(r.size() + blocksize*blocksize);
+  for (int i = 0; i < blocksize; ++i) {
+    for (int j = 0; j < blocksize; ++j) {
+      getR(e,offset+i,offset+j);
+      r.push_back(e.get_d());
+    }
+  }
 }
 
 

--- a/src/gso.h
+++ b/src/gso.h
@@ -609,10 +609,8 @@ inline void MatGSO<ZT, FT>::dumpR_d(double* r, int offset, int blocksize){
   }
 
   for (int i = 0; i < blocksize; ++i) {
-    for (int j = 0; j < blocksize; ++j) {
-      getR(e,offset+i,offset+j);
-      r[i*blocksize+j] = e.get_d();
-    }
+    getR(e,offset+i, offset+i);
+    r[i] = e.get_d();
   }
 }
 
@@ -625,10 +623,8 @@ inline void MatGSO<ZT, FT>::dumpR_d(vector<double> r, int offset, int blocksize)
 
   r.reserve(r.size() + blocksize*blocksize);
   for (int i = 0; i < blocksize; ++i) {
-    for (int j = 0; j < blocksize; ++j) {
-      getR(e,offset+i,offset+j);
-      r.push_back(e.get_d());
-    }
+    getR(e,offset+i,offset+i);
+    r.push_back(e.get_d());
   }
 }
 


### PR DESCRIPTION
This pull requests adds several utility functions to dump the internal state of the GSO to double arrays for further consumption by third party libraries.